### PR TITLE
Adding tests and other code quality checks, fixing a couple of issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+language: php
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - vendor
+
+php:
+    - 7.1
+    - 7.2
+    - 7.3
+    - 7.4snapshot
+    - nightly
+    
+before_install:
+    - phpenv config-rm xdebug.ini || true
+
+install:
+  - if [[ "$DEPS" = 'high' ]]; then travis_retry composer $DEFAULT_COMPOSER_FLAGS update; fi
+  - if [[ "$DEPS" = 'low' ]]; then travis_retry composer $DEFAULT_COMPOSER_FLAGS --prefer-lowest --prefer-stable update; fi
+  - if [[ "$DEPS" = 'stable' ]]; then travis_retry composer $DEFAULT_COMPOSER_FLAGS --prefer-stable update; fi
+  - ./vendor/bin/psalm --version
+
+matrix:
+  allow_failures:
+    - php: 7.4snapshot
+    - php: nightly
+
+script: composer check
+
+env:
+    matrix:
+        - DEPS="low"
+        - DEPS="high"
+        - DEPS="stable"
+    global:
+        - DEFAULT_COMPOSER_FLAGS="--no-interaction --no-suggest"
+        - COMPOSER_DISCARD_CHANGES=1

--- a/Plugin.php
+++ b/Plugin.php
@@ -10,9 +10,21 @@ class Plugin implements PluginEntryPointInterface
     /** @return void */
     public function __invoke(RegistrationInterface $registration, SimpleXMLElement $config = null)
     {
-    	$registration->addStubFile(__DIR__ . '/stubs/Mockery.php');
-    	
-    	require_once __DIR__ . '/hooks/MockReturnTypeUpdater.php';
+        $registration->addStubFile(__DIR__ . '/stubs/Mockery.php');
+
+        if (class_exists('PHPUnit_Framework_TestCase')
+            || (class_exists('\PHPUnit\Runner\Version')
+                && version_compare(\PHPUnit\Runner\Version::id(), '8.0.0', '<')
+            )
+        ) {
+            $registration->addStubFile(__DIR__ . '/stubs/Mockery/AssertPostConditionsV7.php');
+        } elseif (class_exists('\PHPUnit\Runner\Version')
+            && version_compare(\PHPUnit\Runner\Version::id(), '8.0.0', '>=')
+        ) {
+            $registration->addStubFile(__DIR__ . '/stubs/Mockery/AssertPostConditionsV8.php');
+        }
+
+        require_once __DIR__ . '/hooks/MockReturnTypeUpdater.php';
         $registration->registerHooksFromClass(Hooks\MockReturnTypeUpdater::class);
     }
 }

--- a/codeception.yml
+++ b/codeception.yml
@@ -1,0 +1,11 @@
+namespace: Psalm\MockeryPlugin\Tests
+paths:
+    tests: tests
+    output: tests/_output
+    data: tests/_data
+    support: tests/_support
+    envs: tests/_envs
+actor_suffix: Tester
+extensions:
+    enabled:
+        - Codeception\Extension\RunFailed

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,11 @@
         "vimeo/psalm": "^3.0.2"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3.3"
+        "codeception/base": "^2.5",
+        "muglug/package-versions-56": "^1.2",
+        "squizlabs/php_codesniffer": "^3.3.1",
+        "weirdan/codeception-psalm-module": "^0.2.1",
+        "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0"
     },
     "extra": {
         "psalm": {
@@ -26,6 +30,11 @@
             "Psalm\\MockeryPlugin\\": ["."]
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Psalm\\MockeryPlugin\\Tests\\": ["tests/_support"]
+        }
+    },
     "scripts" : {
         "check": [
             "@cs-check",
@@ -33,7 +42,8 @@
             "@analyze"
         ],
         "analyze": "psalm",
-        "cs-check": "phpcs",
-        "cs-fix": "phpcbf"
+        "cs-check": "phpcs -s",
+        "cs-fix": "phpcbf",
+        "test": "codecept run -v"
     }
 }

--- a/hooks/MockReturnTypeUpdater.php
+++ b/hooks/MockReturnTypeUpdater.php
@@ -51,7 +51,16 @@ class MockReturnTypeUpdater implements Hook\AfterMethodCallAnalysisInterface
                 && $first_arg->right instanceof PhpParser\Node\Scalar\String_
                 && $first_arg->right->value[0] === '['
             ) {
-                $fq_class_name = $first_arg->left->class->getAttribute('resolvedName');
+                /** @var PhpParser\Node\Expr\ClassConstFetch $left */
+                $left = $first_arg->left;
+                $fq_class_name = $left->class->getAttribute('resolvedName');
+            } elseif ($first_arg instanceof PhpParser\Node\Scalar\String_) {
+                $bracket_position = strpos($first_arg->value, '[');
+                $fq_class_name = substr(
+                    $first_arg->value,
+                    0,
+                    $bracket_position === false ? strlen($first_arg->value) : $bracket_position
+                );
             }
 
             if ($fq_class_name) {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<ruleset name="mockery-psalm-plugin">
+    <!-- display progress -->
+    <arg value="p"/>
+    <arg name="colors"/>
+
+    <!-- Paths to check -->
+    <file>Plugin.php</file>
+    <file>tests/_support/Helper</file>
+    <file>tests/_support/AcceptanceTester.php</file>
+    <file>hooks</file>
+    <file>stubs</file>
+
+    <!-- inherit rules from: -->
+    <rule ref="PSR12"/>
+
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+    <rule ref="Generic.Files.ByteOrderMark"/>
+    <rule ref="Generic.Files.LineEndings"/>
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="absoluteLineLimit" value="120"/><!-- even though psr-2 specifies it as soft-limit only -->
+        </properties>
+    </rule>
+    <rule ref="Generic.PHP.DeprecatedFunctions"/>
+    <rule ref="Generic.PHP.ForbiddenFunctions"/>
+
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
+        <properties>
+            <property name="ignoreBlankLines" value="false"/>
+        </properties>
+    </rule>
+</ruleset>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="false"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="." />
+        <ignoreFiles>
+            <directory name="vendor" />
+            <directory name="stubs" />
+            <directory name="tests/_support/_generated" />
+            <directory name="tests/_run" />
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <LessSpecificReturnType errorLevel="info" />
+    </issueHandlers>
+
+    <plugins>
+        <pluginClass class="Psalm\MockeryPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/stubs/Mockery.php
+++ b/stubs/Mockery.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable PSR1.Classes.ClassDeclaration.MultipleClasses
 
 namespace
 {
@@ -11,7 +12,9 @@ namespace
          *
          * @return \Mockery\Mock
          */
-        public static function mock(...$args) {}
+        public static function mock(...$args)
+        {
+        }
 
         /**
          * Static and semantic shortcut for getting a mock from the container
@@ -21,7 +24,9 @@ namespace
          *
          * @return \Mockery\MockInterface
          */
-        public static function spy(...$args) {}
+        public static function spy(...$args)
+        {
+        }
 
         /**
          * Return instance of ANYOF matcher.
@@ -30,7 +35,9 @@ namespace
          *
          * @return \Mockery\Matcher\AnyOf
          */
-        public static function anyOf(...$args) {}
+        public static function anyOf(...$args)
+        {
+        }
 
         /**
          * Return instance of NOTANYOF matcher.
@@ -39,7 +46,9 @@ namespace
          *
          * @return \Mockery\Matcher\NotAnyOf
          */
-        public static function notAnyOf(...$args) {}
+        public static function notAnyOf(...$args)
+        {
+        }
     }
 }
 
@@ -59,17 +68,23 @@ namespace Mockery
          *
          * @return \Mockery\ExpectationInterface&static
          */
-        public function shouldReceive(...$methodNames) {}
+        public function shouldReceive(...$methodNames)
+        {
+        }
 
         /**
          * @return static
          */
-        public function makePartial() {}
+        public function makePartial()
+        {
+        }
 
         /**
          * @return static
          */
-        public function shouldAllowMockingProtectedMethods() {}
+        public function shouldAllowMockingProtectedMethods()
+        {
+        }
     }
 
     /**
@@ -239,7 +254,9 @@ namespace Mockery
          * @param mixed ...$args
          * @return static
          */
-        public function andReturn(...$args) {}
+        public function andReturn(...$args)
+        {
+        }
 
         /**
          * Expected argument setter for the expectation
@@ -259,6 +276,10 @@ namespace Mockery
          * @param array|\Closure $argsOrClosure
          * @return static
          */
-        public function withArgs($argsOrClosure) {}
+        public function withArgs($argsOrClosure)
+        {
+        }
     }
 }
+
+// phpcs:enable

--- a/stubs/Mockery/AssertPostConditionsV7.php
+++ b/stubs/Mockery/AssertPostConditionsV7.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Mockery\Adapter\Phpunit
+{
+    trait MockeryPHPUnitIntegrationAssertPostConditions
+    {
+        use MockeryPHPUnitIntegrationAssertPostConditionsForV7AndPrevious;
+    }
+}

--- a/stubs/Mockery/AssertPostConditionsV8.php
+++ b/stubs/Mockery/AssertPostConditionsV8.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Mockery\Adapter\Phpunit
+{
+    trait MockeryPHPUnitIntegrationAssertPostConditions
+    {
+        use MockeryPHPUnitIntegrationAssertPostConditionsForV8;
+    }
+}

--- a/tests/_output/.gitignore
+++ b/tests/_output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/_run/.gitignore
+++ b/tests/_run/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -1,0 +1,24 @@
+<?php
+namespace Psalm\MockeryPlugin\Tests;
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method \Codeception\Actor execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class AcceptanceTester extends \Codeception\Actor
+{
+    use _generated\AcceptanceTesterActions;
+   /**
+    * Define custom actions here
+    */
+}

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -16,29 +16,6 @@ class Acceptance extends \Codeception\Module
     ];
 
     /**
-     * @Given /I have Psalm (newer than|older than) "([0-9.]+)" \(because of "([^"]+)"\)/
-     *
-     * @return void
-     */
-    public function havePsalmOfACertainVersionRangeBecauseOf(string $operator, string $version, string $reason)
-    {
-        if (!isset(self::VERSION_OPERATORS[$operator])) {
-            throw new TestRuntimeException("Unknown operator: $operator");
-        }
-        $op = (string) self::VERSION_OPERATORS[$operator];
-        $currentVersion = (string) Versions::getShortVersion('vimeo/psalm');
-        $this->debug(sprintf("Current version: %s", $currentVersion));
-        $parser = new VersionParser();
-        $currentVersion = $parser->normalize($currentVersion);
-        $version = $parser->normalize($version);
-        $result = Comparator::compare($currentVersion, $op, $version);
-        $this->debug("Comparing $currentVersion $op $version => $result");
-        if (!$result) {
-            throw new Skip("This scenario requires Psalm $op $version because of $reason");
-        }
-    }
-
-    /**
      * @Given /I have Mockery (newer than|older than) "([0-9.]+)" \(because of "([^"]+)"\)/
      *
      * @return void

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -1,0 +1,63 @@
+<?php
+namespace Psalm\MockeryPlugin\Tests\Helper;
+use Codeception\Exception\Skip;
+use Codeception\Exception\TestRuntimeException;
+use Composer\Semver\Comparator;
+use Composer\Semver\VersionParser;
+use Muglug\PackageVersions\Versions;
+// here you can define custom actions
+// all public methods declared in helper class will be available in $I
+class Acceptance extends \Codeception\Module
+{
+    /** @var array<string,string */
+    const VERSION_OPERATORS = [
+        'newer than' => '>',
+        'older than' => '<',
+    ];
+
+    /**
+     * @Given /I have Psalm (newer than|older than) "([0-9.]+)" \(because of "([^"]+)"\)/
+     *
+     * @return void
+     */
+    public function havePsalmOfACertainVersionRangeBecauseOf(string $operator, string $version, string $reason)
+    {
+        if (!isset(self::VERSION_OPERATORS[$operator])) {
+            throw new TestRuntimeException("Unknown operator: $operator");
+        }
+        $op = (string) self::VERSION_OPERATORS[$operator];
+        $currentVersion = (string) Versions::getShortVersion('vimeo/psalm');
+        $this->debug(sprintf("Current version: %s", $currentVersion));
+        $parser = new VersionParser();
+        $currentVersion = $parser->normalize($currentVersion);
+        $version = $parser->normalize($version);
+        $result = Comparator::compare($currentVersion, $op, $version);
+        $this->debug("Comparing $currentVersion $op $version => $result");
+        if (!$result) {
+            throw new Skip("This scenario requires Psalm $op $version because of $reason");
+        }
+    }
+
+    /**
+     * @Given /I have Mockery (newer than|older than) "([0-9.]+)" \(because of "([^"]+)"\)/
+     *
+     * @return void
+     */
+    public function haveMockeryOfACertainVersionRangeBecauseOf(string $operator, string $version, string $reason)
+    {
+        if (!isset(self::VERSION_OPERATORS[$operator])) {
+            throw new TestRuntimeException("Unknown operator: $operator");
+        }
+        $op = (string) self::VERSION_OPERATORS[$operator];
+        $currentVersion = (string) Versions::getShortVersion('mockery/mockery');
+        $this->debug(sprintf("Current version: %s", $currentVersion));
+        $parser = new VersionParser();
+        $currentVersion = $parser->normalize($currentVersion);
+        $version = $parser->normalize($version);
+        $result = Comparator::compare($currentVersion, $op, $version);
+        $this->debug("Comparing $currentVersion $op $version => $result");
+        if (!$result) {
+            throw new Skip("This scenario requires Mockery $op $version because of $reason");
+        }
+    }
+}

--- a/tests/_support/_generated/.gitignore
+++ b/tests/_support/_generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -1,0 +1,7 @@
+actor: AcceptanceTester
+modules:
+    enabled:
+        - Cli
+        - Filesystem
+        - \Weirdan\Codeception\Psalm\Module
+        - \Psalm\MockeryPlugin\Tests\Helper\Acceptance

--- a/tests/acceptance/MockReturn.feature
+++ b/tests/acceptance/MockReturn.feature
@@ -1,0 +1,78 @@
+Feature: MockReturn
+  
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="true">
+        <projectFiles>
+          <directory name="."/>
+          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
+        </projectFiles>
+        <plugins>
+          <pluginClass class="Psalm\MockeryPlugin\Plugin"/>
+        </plugins>
+      </psalm>
+      """
+    And I have the following code preamble
+      """
+      <?php
+      namespace NS;
+      use Mockery;
+      
+      """
+    
+  Scenario: Defined method mocking sets proper intersection return type (Psalm 3.0.9 and higher)
+    Given I have the following code
+      """
+      class User
+      {
+          /**
+           * @return void
+           */
+          public function someMethod()
+          {
+          
+          }
+      }
+      
+      $user = Mockery::mock('NS\User[someMethod]', []);
+      
+      if (is_array($user)) {
+      
+      }
+      """
+    And I have Psalm newer than "3.0.8" (because of "error messages changing in 3.0.9")
+    When I run Psalm
+    Then I see these errors
+      | Type            | Message                                                                                                                                 |
+      | DocblockTypeContradiction | Cannot resolve types for $user - docblock-defined type Mockery\MockInterface&NS\User does not contain array<array-key, mixed> |
+    And I see no other errors
+    
+  Scenario: Defined method mocking sets proper intersection return type (Psalm 3.0.8 and lower)
+    Given I have the following code
+      """
+      class User
+      {
+          /**
+           * @return void
+           */
+          public function someMethod()
+          {
+          
+          }
+      }
+      
+      $user = Mockery::mock('NS\User[someMethod]', []);
+      
+      if (is_array($user)) {
+      
+      }
+      """
+    And I have Psalm older than "3.0.9" (because of "error messages changing in 3.0.9")
+    When I run Psalm
+    Then I see these errors
+      | Type            | Message                                                                                                                                 |
+      | DocblockTypeContradiction | Cannot resolve types for $user - docblock-defined type Mockery\MockInterface&NS\User does not contain array<mixed, mixed> |
+    And I see no other errors
+    

--- a/tests/acceptance/MockReturn.feature
+++ b/tests/acceptance/MockReturn.feature
@@ -22,7 +22,7 @@ Feature: MockReturn
       
       """
     
-  Scenario: Defined method mocking sets proper intersection return type (Psalm 3.0.9 and higher)
+  Scenario: Defined method mocking sets proper intersection return type
     Given I have the following code
       """
       class User
@@ -42,37 +42,9 @@ Feature: MockReturn
       
       }
       """
-    And I have Psalm newer than "3.0.8" (because of "error messages changing in 3.0.9")
     When I run Psalm
     Then I see these errors
       | Type            | Message                                                                                                                                 |
-      | DocblockTypeContradiction | Cannot resolve types for $user - docblock-defined type Mockery\MockInterface&NS\User does not contain array<array-key, mixed> |
-    And I see no other errors
-    
-  Scenario: Defined method mocking sets proper intersection return type (Psalm 3.0.8 and lower)
-    Given I have the following code
-      """
-      class User
-      {
-          /**
-           * @return void
-           */
-          public function someMethod()
-          {
-          
-          }
-      }
-      
-      $user = Mockery::mock('NS\User[someMethod]', []);
-      
-      if (is_array($user)) {
-      
-      }
-      """
-    And I have Psalm older than "3.0.9" (because of "error messages changing in 3.0.9")
-    When I run Psalm
-    Then I see these errors
-      | Type            | Message                                                                                                                                 |
-      | DocblockTypeContradiction | Cannot resolve types for $user - docblock-defined type Mockery\MockInterface&NS\User does not contain array<mixed, mixed> |
+      | DocblockTypeContradiction | Cannot resolve types for $user - docblock-defined type Mockery\MockInterface&NS\User does not contain array<%, mixed> |
     And I see no other errors
     

--- a/tests/acceptance/PHPUnitIntegration.feature
+++ b/tests/acceptance/PHPUnitIntegration.feature
@@ -1,0 +1,62 @@
+Feature: PHPUnitIntegration
+  
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="true">
+        <projectFiles>
+          <directory name="."/>
+          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
+        </projectFiles>
+        <plugins>
+          <pluginClass class="Psalm\MockeryPlugin\Plugin"/>
+        </plugins>
+      </psalm>
+      """
+    And I have the following code preamble
+      """
+      <?php
+      namespace NS;
+      use Mockery;
+      use PHPUnit\Framework\TestCase;
+      
+      """
+    
+  Scenario: Mockery trait does not cause Psalm to throw fatal error
+    Given I have the following code
+      """
+      class MyTestCase extends TestCase
+      {
+          use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+      
+          /**
+           * @return void
+           */
+          public function testSomething()
+          {
+          
+          }
+      }
+      """
+    And I have Mockery newer than "0.9.99" (because of "Trait added in Mockery 1.0")
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: Plugin stubs don't conflict with Mockery 0.9.x
+      Given I have the following code
+        """
+        class MyTestCase extends TestCase
+        {
+            /**
+             * @return void
+             */
+            public function testSomething()
+            {
+                $mock = Mockery::mock(\ArrayAccess::class);
+            }
+        }
+        """
+      And I have Mockery older than "1.0" (because of "Traits were added in Mockery 1.0")
+      When I run Psalm
+      Then I see no errors


### PR DESCRIPTION
This PR adds tests and other code quality checks to this plugin (seems like the foundation was there for this but not everything was in place, like config files for psalm/phpcs).  I "stole" most of this skeleton from the psalm phpunit plugin (https://github.com/psalm/phpunit-psalm-plugin thanks @weirdan for your work on that).

I think this repo will have to be enabled in Travis in order to have the tests run against this PR. I did confirm that all checks are green on my branch (except for PHP 7.4 and Nightly, which are having build issues generally right now due to a missing library file). Here's the last build for my branch: https://travis-ci.org/jaydiablo/mockery-psalm-plugin/builds/518856454

I tried to add tests that covered the cases that I've run into recently when testing this plugin:

* #1 - I've added an additional modification to the return type when the first parameter to `Mockery::mock` is a string (and it may or may not be in the format of `ClassName[methodName1,methodName2]`). The test I added for this intentionally triggers a psalm error in order to verify that the expected type is an intersection type (`ClassName&\Mockery\MockInterface`).  I had difficulty getting that test to fail otherwise.
* https://github.com/vimeo/psalm/issues/1537 - I've added a couple of different stubs that are loaded based on the detected PHPUnit version (using basically the same logic that Mockery is using to determine which class to use as the alias). I was able to confirm that the test I added would fail just as my installation of Psalm does without these stubs present (a Fatal Error is thrown during the analyze phase).

I've also pointed my project to this branch of my fork and confirmed that the issues I was seeing are no longer present with these changes (Mockery 1.x and PHPUnit 6.x).

I'll add some inline comments to point out the reasoning for some specific changes.