### PR TITLE
Mockery::mock returns a MockInterface

### DIFF
--- a/stubs/Mockery.php
+++ b/stubs/Mockery.php
@@ -9,7 +9,7 @@ namespace
          *
          * @param mixed ...$args
          *
-         * @return \Mockery\Mock
+         * @return \Mockery\MockInterface
          */
         public static function mock(...$args) {}
 


### PR DESCRIPTION
`Mockery::mock` actually returns a `MockInterface`, not a `Mock` object.

https://github.com/mockery/mockery/blob/master/library/Mockery.php#L109-L119