### PR TITLE
Don't force legacy package versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     },
     "require-dev": {
         "codeception/base": "^2.5",
-        "muglug/package-versions-56": "^1.2",
         "squizlabs/php_codesniffer": "^3.3.1",
         "weirdan/codeception-psalm-module": "^0.2.1",
         "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0"

--- a/hooks/MockReturnTypeUpdater.php
+++ b/hooks/MockReturnTypeUpdater.php
@@ -67,7 +67,7 @@ class MockReturnTypeUpdater implements Hook\AfterMethodCallAnalysisInterface
                 foreach ($return_type_candidate->getTypes() as $return_atomic_type) {
                     if ($return_atomic_type instanceof Type\Atomic\TNamedObject) {
                         $return_atomic_type->value = 'Mockery\MockInterface';
-                        $return_atomic_type->extra_types[] = new Type\Atomic\TNamedObject($fq_class_name);
+                        $return_atomic_type->addIntersectionType(new Type\Atomic\TNamedObject($fq_class_name));
                         break;
                     }
                 }

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -4,7 +4,9 @@ use Codeception\Exception\Skip;
 use Codeception\Exception\TestRuntimeException;
 use Composer\Semver\Comparator;
 use Composer\Semver\VersionParser;
-use Muglug\PackageVersions\Versions;
+use Muglug\PackageVersions\Versions as LegacyVersions;
+use PackageVersions\Versions as Versions;
+use RuntimeException;
 // here you can define custom actions
 // all public methods declared in helper class will be available in $I
 class Acceptance extends \Codeception\Module
@@ -26,7 +28,7 @@ class Acceptance extends \Codeception\Module
             throw new TestRuntimeException("Unknown operator: $operator");
         }
         $op = (string) self::VERSION_OPERATORS[$operator];
-        $currentVersion = (string) Versions::getShortVersion('mockery/mockery');
+        $currentVersion = $this->getShortVersion('mockery/mockery');
         $this->debug(sprintf("Current version: %s", $currentVersion));
         $parser = new VersionParser();
         $currentVersion = $parser->normalize($currentVersion);
@@ -36,5 +38,26 @@ class Acceptance extends \Codeception\Module
         if (!$result) {
             throw new Skip("This scenario requires Mockery $op $version because of $reason");
         }
+    }
+
+    private function getShortVersion(string $package): string
+    {
+        if (class_exists(Versions::class)) {
+            /** @psalm-suppress UndefinedClass psalm 3.0 ignores class_exists check */
+            $version = (string) Versions::getVersion($package);
+        } elseif (class_exists(LegacyVersions::class)) {
+            $version = (string) LegacyVersions::getVersion($package);
+        } else {
+            throw new RuntimeException(
+                'Neither muglug/package-versions-56 nor ocramius/package-version is available,'
+                . ' cannot determine versions'
+            );
+        }
+
+        if (false === strpos($version, '@')) {
+            throw new RuntimeException('$version must contain @');
+        }
+
+        return explode('@', $version)[0];
     }
 }

--- a/tests/acceptance/PHPUnitIntegration.feature
+++ b/tests/acceptance/PHPUnitIntegration.feature
@@ -1,5 +1,5 @@
 Feature: PHPUnitIntegration
-  
+
   Background:
     Given I have the following config
       """
@@ -20,22 +20,23 @@ Feature: PHPUnitIntegration
       namespace NS;
       use Mockery;
       use PHPUnit\Framework\TestCase;
-      
+
       """
-    
+
   Scenario: Mockery trait does not cause Psalm to throw fatal error
     Given I have the following code
       """
+      /** @psalm-suppress PropertyNotSetInConstructor */
       class MyTestCase extends TestCase
       {
           use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
-      
+
           /**
            * @return void
            */
           public function testSomething()
           {
-          
+
           }
       }
       """


### PR DESCRIPTION
Use whatever Psalm brings in: either `muglug/package-versions-56` or `ocramius/package-versions`.

Also fixed build failures.