### PR TITLE
add support for alias: and overload: mocks

### DIFF
--- a/hooks/MockReturnTypeUpdater.php
+++ b/hooks/MockReturnTypeUpdater.php
@@ -55,9 +55,15 @@ class MockReturnTypeUpdater implements Hook\AfterMethodCallAnalysisInterface
                 $left = $first_arg->left;
                 $fq_class_name = $left->class->getAttribute('resolvedName');
             } elseif ($first_arg instanceof PhpParser\Node\Scalar\String_) {
+                if (substr($first_arg->value, 0, 6) === 'alias:') {
+                    $trimmed_value = substr($first_arg->value, 6);
+                } elseif (substr($first_arg->value, 0, 9) === 'overload:') {
+                    $trimmed_value = substr($first_arg->value, 9);
+                }
+
                 $bracket_position = strpos($first_arg->value, '[');
                 $fq_class_name = substr(
-                    $first_arg->value,
+                    (!isset($trimmed_value) || $trimmed_value === false) ? $first_arg->value : $trimmed_value,
                     0,
                     $bracket_position === false ? strlen($first_arg->value) : $bracket_position
                 );

--- a/tests/acceptance/MockReturn.feature
+++ b/tests/acceptance/MockReturn.feature
@@ -48,3 +48,26 @@ Feature: MockReturn
       | DocblockTypeContradiction | Cannot resolve types for $user - docblock-defined type Mockery\MockInterface&NS\User does not contain array<%, mixed> |
     And I see no other errors
     
+  Scenario: Alias class mocking is recognized
+    Given I have the following code
+      """
+      class User
+      {
+      }
+      
+      $user = Mockery::mock('alias:NS\User')->shouldReceive('someMethod');
+      """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: Overload class mocking is recognized
+    Given I have the following code
+      """
+      class User
+      {
+      }
+      
+      $user = Mockery::mock('overload:NS\User')->shouldReceive('someMethod');
+      """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
When using this plugin with alias mocking, it would be reported that the class could not be found:

> ERROR: UndefinedClass - path/to/file.php:109:9 - Class or interface alias:MyClass does not exist
>        Mockery::mock('alias:MyClass')->shouldReceive('someMethod')->with(1)->andReturn('test');

This PR adds specific substr trimming of `alias:` and `overload:`, along with tests.