### PR TITLE
fix: mixin expecation so all methods are defined

### DIFF
--- a/stubs/Mockery.php
+++ b/stubs/Mockery.php
@@ -122,6 +122,9 @@ namespace Mockery
         public function shouldAllowMockingProtectedMethods();
     }
 
+    /**
+     * @mixin \Mockery\Expectation
+     */
     interface ExpectationInterface
     {
         /**

--- a/tests/acceptance/MockReturn.feature
+++ b/tests/acceptance/MockReturn.feature
@@ -1,5 +1,5 @@
 Feature: MockReturn
-  
+
   Background:
     Given I have the following config
       """
@@ -21,7 +21,7 @@ Feature: MockReturn
       use Mockery;
       
       """
-    
+
   Scenario: Defined method mocking sets proper intersection return type
     Given I have the following code
       """
@@ -47,14 +47,14 @@ Feature: MockReturn
       | Type            | Message                                                                                                                                 |
       | DocblockTypeContradiction | Cannot resolve types for $user - docblock-defined type Mockery\MockInterface&NS\User does not contain array<%, mixed> |
     And I see no other errors
-    
+
   Scenario: Alias class mocking is recognized
     Given I have the following code
       """
       class User
       {
       }
-      
+
       $user = Mockery::mock('alias:NS\User')->shouldReceive('someMethod');
       """
     When I run Psalm
@@ -66,8 +66,25 @@ Feature: MockReturn
       class User
       {
       }
-      
+
       $user = Mockery::mock('overload:NS\User')->shouldReceive('someMethod');
+      """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: Expectations can be set on mocked instances
+    Given I have the following code
+      """
+      class User
+      {
+          public function getName(): string {
+            return 'name';
+          }
+      }
+      $user = Mockery::mock(User::class);
+      $user
+        ->shouldReceive('getName')->andReturn('feek')
+        ->shouldReceive('foo')->andReturnNull();
       """
     When I run Psalm
     Then I see no errors


### PR DESCRIPTION
I believe this should fix #6 

Unfortunately the `ExpecationInterface` that mockery defines is quite small, and pretty much everyone just depends on the methods defined in `Expectation`.

I think this is an acceptable solution -- otherwise we can change `Mockery::mock` to return an intersection of `Expectation&static`, rather than `ExpectationInterface&static`