### PR TITLE
Fix namespace

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -24,6 +24,6 @@ class Plugin implements PluginEntryPointInterface
         }
 
         require_once __DIR__ . '/hooks/MockReturnTypeUpdater.php';
-        $registration->registerHooksFromClass(Hooks\MockReturnTypeUpdater::class);
+        $registration->registerHooksFromClass(hooks\MockReturnTypeUpdater::class);
     }
 }

--- a/hooks/MockReturnTypeUpdater.php
+++ b/hooks/MockReturnTypeUpdater.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Psalm\MockeryPlugin\Hooks;
+namespace Psalm\MockeryPlugin\hooks;
 
 use PhpParser;
 use Psalm\Codebase;


### PR DESCRIPTION
There is a wrong namespace which prevents updates to composer 2 which is coming soon.

```
Deprecation Notice: Class Psalm\MockeryPlugin\Hooks\MockReturnTypeUpdater located in ./vendor/psalm/plugin-mockery/hooks/MockReturnTypeUpdater.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in /usr/share/php/Composer/Autoload/ClassMapGenerator.php:201
```

It should be possible to fix it also by changes in the autoload entry or renaming the folder.
Just let me know or close the PR and commit yourself.