### PR TITLE
Added .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/phpcs.xml.dist export-ignore
+/psalm.xml.dist export-ignore
+/README.md export-ignore
+/codeception.yml export-ignore
+/.github export-ignore


### PR DESCRIPTION
If Сomposer uses the parameter **"optimize-autoloader": true**, there is a warning:

> Generating optimized autoload files  
> Class Psalm\MockeryPlugin\Tests\AcceptanceTester located in vendor/psalm/plugin-mockery\tests\_support\AcceptanceTester.php does not comply with psr-4 autoloading standard. Skipping.
> Class Psalm\MockeryPlugin\Tests\Helper\Acceptance located in vendor/psalm/plugin-mockery\tests\_support\Helper\Acceptance.php does not comply with psr-4 autoloading standard. Skipping.

Adding .gitattributes solves this problem.
The file code is taken from here: https://github.com/psalm/psalm-plugin-phpunit