### PR TITLE
Remove totallyTyped in favour of errorLevel=1

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="false"
+    errorLevel="1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/tests/acceptance/MockReturn.feature
+++ b/tests/acceptance/MockReturn.feature
@@ -4,7 +4,7 @@ Feature: MockReturn
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/PHPUnitIntegration.feature
+++ b/tests/acceptance/PHPUnitIntegration.feature
@@ -4,7 +4,7 @@ Feature: PHPUnitIntegration
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>


### PR DESCRIPTION
`totallyTyped` was deprecated in Psalm 4 and removed in Psalm 5
