### PR TITLE
Fix issues Psalm identified

### DIFF
--- a/Hooks/MockReturnTypeUpdater.php
+++ b/Hooks/MockReturnTypeUpdater.php
@@ -18,7 +18,8 @@ class MockReturnTypeUpdater implements AfterMethodCallAnalysisInterface
         $return_type_candidate = $event->getReturnTypeCandidate();
         $expr = $event->getExpr();
         $method_id = $event->getMethodId();
-        if ($return_type_candidate
+        if (
+            $return_type_candidate
             && self::isMockMethod($method_id)
             && isset($expr->args[0])
             && $expr->args[0] instanceof Arg


### PR DESCRIPTION
1. Support (and ignore) first-class callables for `Mockery::mock(...)`
   and `Mockery::spy(...)`
2. Fix prefix and bracket logic
3. Drop unused `@var`
4. Force `resolvedName` to be treated as `class-string` (because it is
   a class-string)
